### PR TITLE
Implement continuous chest add functionality

### DIFF
--- a/Supplier/Extensions/TSPlayerExtensions.cs
+++ b/Supplier/Extensions/TSPlayerExtensions.cs
@@ -1,0 +1,12 @@
+using TShockAPI;
+namespace Supplier.Extensions;
+public static class TSPlayerExtensions
+{
+    public static PlayerOperationState GetPlayerOperationState(this TSPlayer tsplayer)
+    {
+        if (!tsplayer.ContainsData("Supplier.PlayerState"))
+            tsplayer.SetData("Supplier.PlayerState", new PlayerOperationState());
+
+        return tsplayer.GetData<PlayerOperationState>("Supplier.PlayerState");
+    }
+}

--- a/Supplier/PlayerOperationState.cs
+++ b/Supplier/PlayerOperationState.cs
@@ -1,0 +1,45 @@
+
+namespace Supplier;
+public class PlayerOperationState
+{
+
+    private bool _infChestAdd;
+    public bool InfChestAdd
+    {
+        get => _infChestAdd;
+        set
+        {
+            if (value) SetAllOperationStatesFalse();
+            _infChestAdd = value;
+        }
+    }
+
+    private bool _infChestAddBulk;
+    public bool InfChestAddBulk
+    {
+        get => _infChestAddBulk;
+        set
+        {
+            if (value) SetAllOperationStatesFalse();
+            _infChestAddBulk = value;
+        }
+    }
+
+    private bool _infChestDelete;
+    public bool InfChestDelete
+    {
+        get => _infChestDelete;
+        set
+        {
+            if (value) SetAllOperationStatesFalse();
+            _infChestDelete = value;
+        }
+    }
+
+    public void SetAllOperationStatesFalse()
+    {
+        _infChestAdd = false;
+        _infChestAddBulk = false;
+        _infChestDelete = false;
+    }
+}


### PR DESCRIPTION
This PR includes a new `/infchest` subcommand: `addbulk`. This allows the player to continuously select chests to convert until `/cancel` is used. 

In addition to this, a slightly more robust way of storing operation states has been included - bundled the booleans into a class and included a `TSPlayer` extension method for retrieval.